### PR TITLE
Update pdf dependencies

### DIFF
--- a/src/android/AndroidNativePdfViewer.gradle
+++ b/src/android/AndroidNativePdfViewer.gradle
@@ -1,5 +1,5 @@
-repositories{    
-  jcenter()
+repositories{
+  mavenCentral()
   flatDir {
       dirs 'libs'
    }
@@ -8,6 +8,7 @@ repositories{
 dependencies {
     implementation(name:'pdfviewer-library', ext:'aar')
     implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'
+    implementation 'com.github.barteksc:pdfium-android:+'
     implementation 'com.android.support:appcompat-v7:27.+'
     implementation 'com.android.support:design:27.+'
 }


### PR DESCRIPTION
## Summary
- use mavenCentral repo
- depend on pdfium-android for latest Pdfium

## Testing
- `gradle dependencies --configuration compileClasspath` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_68654c88dca08326b2c00c75f9f67935